### PR TITLE
feat: add DEPARTMENT_HEAD role and update navigation visibility

### DIFF
--- a/src/components/dashboard/nav/nav.tsx
+++ b/src/components/dashboard/nav/nav.tsx
@@ -30,7 +30,7 @@ const Nav = () => {
       </div>
       <div className="flex items-center space-x-4">
         <span className="w-32 sm:w-auto truncate">{userInfo}</span>
-        {roles && (roles.includes('RH') || roles.includes('VA')) && (
+        {roles && (roles.includes('RH') || roles.includes('VA') || roles.includes('DEPARTMENT_HEAD')) && (
           <div>
             <InboxComponent />
           </div>

--- a/src/constants/roles/roles.ts
+++ b/src/constants/roles/roles.ts
@@ -3,4 +3,5 @@ export enum Roles {
   admin = 'ADMIN',
   rh = 'RH',
   va = 'VA',
+  departmentHead = 'DEPARTMENT_HEAD',
 }


### PR DESCRIPTION
This pull request includes changes to the `Nav` component and the `Roles` enum to support a new role, `DEPARTMENT_HEAD`.

Changes to support the new role:

* [`src/components/dashboard/nav/nav.tsx`](diffhunk://#diff-7ee9ef552e602e6aef7963a2b145b2d584bc19b1162d98e185cd094c668644c8L33-R33): Updated the condition to include the `DEPARTMENT_HEAD` role in the `Nav` component.
* [`src/constants/roles/roles.ts`](diffhunk://#diff-73f80419a067f0350238e9cc5ada6bf031750f01dcc7aa6aca705ff3ad19f8deR6): Added the `DEPARTMENT_HEAD` role to the `Roles` enum.