### PR TITLE
hotfix/ fix the fetch from session validation watcher

### DIFF
--- a/src/app/auth/session-expired/page.tsx
+++ b/src/app/auth/session-expired/page.tsx
@@ -16,7 +16,6 @@ export default function SessionExpired() {
           />
 
           <h1 className="mb-4 text-5xl tracking-tight font-extrabold lg:text-7xl text-primary-600">Sesión Expirada</h1>
-          <p className="mb-4 text-2xl tracking-tight font-bold text-gray-900 md:text-3xl">¡Tu sesión ha expirado!</p>
           <p className="mb-4 text-lg font-light text-gray-500">
             Por motivos de seguridad, tu sesión ha expirado. Por favor, inicia sesión nuevamente para continuar.
           </p>

--- a/src/hooks/auth/session-validation/useSessionValidation.ts
+++ b/src/hooks/auth/session-validation/useSessionValidation.ts
@@ -1,17 +1,22 @@
 import { useEffect, useRef } from "react";
 import { sessionValidation } from "@/services/auth/session-validation/actions";
+import { useSession } from "next-auth/react";
 
 /**
  * Hook que ejecuta sessionValidation cada 5 segundos para validar la sesión.
+ * Solo hace el fetch si el usuario tiene sesión activa.
  * Si la sesión es inválida, ejecuta onInvalidSession.
  * @param onInvalidSession función a ejecutar si la sesión es inválida
  */
 export function useSessionValidation(onInvalidSession?: () => void) {
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const { data: session, status } = useSession();
 
   useEffect(() => {
     let isMounted = true;
     async function validate() {
+      // Solo valida si hay sesión activa
+      if (status !== "authenticated" || !session?.user) return;
       try {
         await sessionValidation();
       } catch (e) {
@@ -26,5 +31,5 @@ export function useSessionValidation(onInvalidSession?: () => void) {
       isMounted = false;
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
-  }, [onInvalidSession]);
+  }, [onInvalidSession, status, session]);
 }


### PR DESCRIPTION
This pull request improves session management and updates the user interface for session expiration. The most important changes include adding session status checks to the `useSessionValidation` hook and refining the messaging on the session expiration page.

### Session Management Enhancements:

* [`src/hooks/auth/session-validation/useSessionValidation.ts`](diffhunk://#diff-c7dbbd84e19424511976d0d30fc63d19dd3a0b4b0196d82dbc9ddaf028e1a086R3-R19): Integrated `useSession` from `next-auth/react` to check the session status and ensure the session validation fetch is only performed when the user is authenticated. Updated the dependency array of the `useEffect` hook to include `status` and `session` for accurate reactivity. [[1]](diffhunk://#diff-c7dbbd84e19424511976d0d30fc63d19dd3a0b4b0196d82dbc9ddaf028e1a086R3-R19) [[2]](diffhunk://#diff-c7dbbd84e19424511976d0d30fc63d19dd3a0b4b0196d82dbc9ddaf028e1a086L29-R34)

### User Interface Update:

* [`src/app/auth/session-expired/page.tsx`](diffhunk://#diff-74b94b3923c5014c2b1e3e6b8589c7dda42688ee5e154e0f84988c5b32802588L19): Removed the redundant bolded message "¡Tu sesión ha expirado!" to streamline the session expiration page and maintain a concise user interface.