### PR TITLE
feat: add pagination parameters to department fetching in job positio…

### DIFF
--- a/src/components/system-configuration/job-positions/edit-job-positions-modal.tsx
+++ b/src/components/system-configuration/job-positions/edit-job-positions-modal.tsx
@@ -35,7 +35,10 @@ export default function EditJobPositionsModal({ jobPosition }: Props) {
       jobPositionId: jobPosition.id,
     });
 
-  const { departments } = useGetAllDepartments();
+  const { departments } = useGetAllDepartments({
+    page: '1',
+    limit: '30',
+  });
 
   return (
     <>

--- a/src/components/system-configuration/job-positions/job-positions-table.tsx
+++ b/src/components/system-configuration/job-positions/job-positions-table.tsx
@@ -29,7 +29,9 @@ export default function JobPositionsTable() {
     limit: String(itemsPerPage),
     name: debouncedSearch || undefined
   })
-  const { departments = [] } = useGetAllDepartments()
+  const { departments = [] } = useGetAllDepartments(
+    {page: '1', limit: '30'},
+  )
 
   // Update URL when search or page changes
   useEffect(() => {


### PR DESCRIPTION
This pull request updates the `useGetAllDepartments` hook calls in the job positions module to include pagination parameters (`page` and `limit`). This ensures consistent data retrieval behavior across components.

### Updates to `useGetAllDepartments` hook:

* [`src/components/system-configuration/job-positions/edit-job-positions-modal.tsx`](diffhunk://#diff-7c0abb29332ad4aa7073da141fccf6c9e023a80c328dfc4a0b6828f588c76897L38-R41): Updated the `useGetAllDepartments` call to include `page: '1'` and `limit: '30'` as parameters.
* [`src/components/system-configuration/job-positions/job-positions-table.tsx`](diffhunk://#diff-8728e7588d695f99c18f77f8573fc099e4cb004d13265f6ac1adecc4e8c6afd2L32-R34): Added `page: '1'` and `limit: '30'` parameters to the `useGetAllDepartments` call, ensuring consistent pagination.…ns components