### PR TITLE
feat: update vacation request form to swap entry and departure dates …

### DIFF
--- a/src/components/request/request-vacation/request-vacation-form.tsx
+++ b/src/components/request/request-vacation/request-vacation-form.tsx
@@ -81,8 +81,8 @@ export default function RequestVacationForm() {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     if (date?.from && date?.to) {
-      setValue("entryDate", format(date.from, 'yyyy-MM-dd'))
-      setValue("departureDate", format(date.to, 'yyyy-MM-dd'))
+      setValue("departureDate", format(date.from, 'yyyy-MM-dd')) // Fecha de salida es la fecha inicial
+      setValue("entryDate", format(date.to, 'yyyy-MM-dd'))      // Fecha de entrada es la fecha final
       submitVacationRequest()
     }
   }
@@ -94,6 +94,7 @@ export default function RequestVacationForm() {
       </h5>
       <p className="mb-4 text-sm font-normal text-gray-500 dark:text-gray-400">
         Por favor, selecciona el rango de fechas para tu solicitud de vacaciones.
+        La fecha inicial será tu fecha de salida y la fecha final será tu fecha de regreso.
       </p>
       <Flag />
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,6 +21,25 @@ export async function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
+  // Manejo especial para la ruta de sesión expirada
+  if (pathname === '/auth/session-expired') {
+    const session = await getToken({
+      req,
+      secret: process.env.NEXTAUTH_SECRET,
+    });
+
+    if (session) {
+      // Limpiar la cookie de sesión
+      const response = NextResponse.next();
+      response.cookies.delete('next-auth.session-token');
+      response.cookies.delete('next-auth.csrf-token');
+      response.cookies.delete('__Secure-next-auth.session-token');
+      response.cookies.delete('__Secure-next-auth.csrf-token');
+      return response;
+    }
+    return NextResponse.next();
+  }
+
   // 2. Permitir rutas públicas
   if (isPublicRoute(pathname)) {
     return NextResponse.next();


### PR DESCRIPTION
This pull request introduces changes to the vacation request form and middleware logic. The updates include fixing a logic issue in date handling, clarifying instructions for users, and adding a special case for handling expired session routes in middleware.

### Vacation Request Form Updates:
* Corrected the logic in `handleSubmit` to ensure that "departureDate" corresponds to the start date and "entryDate" corresponds to the end date. Added inline comments for clarification. (`src/components/request/request-vacation/request-vacation-form.tsx`, [src/components/request/request-vacation/request-vacation-form.tsxL84-R85](diffhunk://#diff-88cb8bb451bf2183c01e038dbac73bf37c89e4d754daa5ade594404cff9253cbL84-R85))
* Updated the user instructions to clarify that the start date is the departure date and the end date is the return date. (`src/components/request/request-vacation/request-vacation-form.tsx`, [src/components/request/request-vacation/request-vacation-form.tsxR97](diffhunk://#diff-88cb8bb451bf2183c01e038dbac73bf37c89e4d754daa5ade594404cff9253cbR97))

### Middleware Enhancements:
* Added special handling for the `/auth/session-expired` route. If a valid session exists, session-related cookies are cleared before proceeding. (`src/middleware.ts`, [src/middleware.tsR24-R42](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0R24-R42))…and clarify date selection instructions