### PR TITLE
feat: implement session management on session expired page

### DIFF
--- a/src/app/auth/session-expired/page.tsx
+++ b/src/app/auth/session-expired/page.tsx
@@ -1,8 +1,20 @@
+"use client"
+
 import { Button } from "@/components/ui/button"
 import Image from "next/image"
 import Link from "next/link"
+import { signOut, useSession } from "next-auth/react"
+import { useEffect } from "react"
 
 export default function SessionExpired() {
+  const { data: session } = useSession()
+
+  useEffect(() => {
+    if (session) {
+      signOut({ redirect: false })
+    }
+  }, [session])
+
   return (
     <section className="flex bg-white min-h-screen justify-center items-center">
       <div className="py-5 px-4 mx-auto max-w-(--breakpoint-xl) lg:py-16 lg:px-6">


### PR DESCRIPTION
This pull request updates the `SessionExpired` page to enhance session management by automatically signing out users when a session is detected. 

### Session Management Enhancements:
* [`src/app/auth/session-expired/page.tsx`](diffhunk://#diff-74b94b3923c5014c2b1e3e6b8589c7dda42688ee5e154e0f84988c5b32802588R1-R17): Added `useSession` and `signOut` from `next-auth/react` to monitor session status. Implemented a `useEffect` hook to trigger `signOut` automatically if a session is active, preventing unintended access.